### PR TITLE
Replace `logging.exception` with `logging.error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ python3 -m pip install reflectivity_ui*.whl
 
 ## Run
 
-Work in progress.
+```bash
+bin/quicknxs2
+```
 
 ## Test
 

--- a/reflectivity_ui/interfaces/configuration.py
+++ b/reflectivity_ui/interfaces/configuration.py
@@ -140,7 +140,7 @@ class Configuration(object):
             try:
                 self.from_q_settings(settings)
             except:
-                logging.exception("Could not process application settings")
+                logging.error("Could not process application settings")
 
     @property
     def peak_roi(self):

--- a/reflectivity_ui/interfaces/data_handling/data_info.py
+++ b/reflectivity_ui/interfaces/data_handling/data_info.py
@@ -428,5 +428,5 @@ class Fitter2(object):
             peak_min = max(peak_min, self.DEAD_PIXELS)
             peak_max = min(peak_max, self.n_x - self.DEAD_PIXELS)
         except:
-            logging.exception("Could not fit the beam width")
+            logging.error("Could not fit the beam width")
         return [peak_min, peak_max]

--- a/reflectivity_ui/interfaces/data_handling/data_manipulation.py
+++ b/reflectivity_ui/interfaces/data_handling/data_manipulation.py
@@ -507,7 +507,7 @@ def extract_meta_data(file_path=None, cross_section_data=None, configuration=Non
         meta_data.mid_q = Instrument.mid_q_value(ws)
         meta_data.is_direct_beam = Instrument.check_direct_beam(ws)
     except:
-        logging.exception("Exception extracting metadata")
+        logging.error("Exception extracting metadata")
         raise RuntimeError("Could not load file %s [%s]" % (file_path, keys[0]))
 
     return meta_data

--- a/reflectivity_ui/interfaces/data_handling/data_set.py
+++ b/reflectivity_ui/interfaces/data_handling/data_set.py
@@ -171,7 +171,7 @@ class NexusData(object):
                         setattr(self.cross_sections[xs].configuration, param, value)
                         has_changed = True
         except:
-            logging.exception("Could not set parameter %s %s", param, value)
+            logging.error("Could not set parameter %s %s", param, value)
         return has_changed
 
     def calculate_reflectivity(self, direct_beam=None, configuration=None):
@@ -300,7 +300,7 @@ class NexusData(object):
                     xs,
                     traceback.format_exc(),
                 )
-                logging.exception("Could not calculate GISANS reflectivity for %s", xs)
+                logging.error("Could not calculate GISANS reflectivity for %s", xs)
             if progress:
                 progress(i, message="Computed GISANS %s" % xs, out_of=len(self.cross_sections))
         if has_errors:
@@ -342,7 +342,7 @@ class NexusData(object):
                     xs,
                     traceback.format_exc(),
                 )
-                logging.exception(detailed_msg)
+                logging.error(detailed_msg)
         if has_errors:
             raise RuntimeError(detailed_msg)
 
@@ -355,7 +355,7 @@ class NexusData(object):
             try:
                 self.cross_sections[xs].update_configuration(configuration)
             except:
-                logging.exception("Could not update configuration for %s", xs)
+                logging.error("Could not update configuration for %s", xs)
 
     def update_calculated_values(self):
         """
@@ -382,7 +382,7 @@ class NexusData(object):
             xs_list = self.configuration.instrument.load_data(self.file_path)
             logging.info("%s loaded: %s xs", self.file_path, len(xs_list))
         except RuntimeError as run_err:
-            logging.exception("Could not load file(s) {}\n   {}".format(str(self.file_path), run_err))
+            logging.error("Could not load file(s) {}\n   {}".format(str(self.file_path), run_err))
             return self.cross_sections
 
         progress_value = 0
@@ -672,7 +672,7 @@ class CrossSectionData(object):
                     self.logs[motor] = np.float64(stats.mean)
                     self.log_minmax[motor] = (np.float64(stats.minimum), np.float64(stats.maximum))
             except:
-                logging.exception("Error reading DASLogs %s", motor)
+                logging.error("Error reading DASLogs %s", motor)
 
         self.proton_charge = data["gd_prtn_chrg"].value
         self.total_counts = workspace.getNumberEvents()

--- a/reflectivity_ui/interfaces/data_handling/processing_workflow.py
+++ b/reflectivity_ui/interfaces/data_handling/processing_workflow.py
@@ -319,7 +319,7 @@ class ProcessingWorkflow(object):
                     self.data_manager.cached_offspec = smooth_output
                 except:
                     raise
-                    logging.exception("Problem writing smooth off-spec output")
+                    logging.error("Problem writing smooth off-spec output")
             else:
                 # Binned version
                 binned_data, slice_data_dict = self.get_rebinned_offspec_data()

--- a/reflectivity_ui/interfaces/main_window.py
+++ b/reflectivity_ui/interfaces/main_window.py
@@ -284,7 +284,7 @@ class MainWindow(QtWidgets.QMainWindow):
                         self.data_manager.calculate_reflectivity(configuration=configuration, active_only=active_only)
                     except Exception:
                         self.file_handler.report_message("There was a problem updating the reflectivity", pop_up=False)
-                        logging.exception("There was a problem updating the reflectivity")
+                        logging.error("There was a problem updating the reflectivity")
                 self.plot_manager.plot_refl()
                 self.update_specular_viewer.emit()
 
@@ -374,7 +374,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.data_manager.calculate_reflectivity()
             except Exception:
                 self.file_handler.report_message("There was a problem updating the reflectivity", pop_up=False)
-                logging.exception("There was a problem updating the reflectivity")
+                logging.error("There was a problem updating the reflectivity")
             self.initiate_reflectivity_plot.emit(True)
 
     def openByNumber(self):


### PR DESCRIPTION
# Short description of the changes:
Using `logging.exception` resulted in tests failing. Per the [documentation](https://docs.python.org/3/library/logging.html#logging.Logger.exception), `logging.exception` should only be used inside exception handlers. Not sure why this was not failing before

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
