### PR TITLE
Hide Sample Size and Bandwidth Configuration

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -26,6 +26,7 @@ detector saturation.
 
 **Of interest to the User**:
 
+- PR #124: Hides the "Sample Size" and "Bandwidth" configurations
 - PR #120: rename the launcher script to "quicknxs-gui"
 - PR #119: Rename the repository to "quicknxs"
 - PR #115: Skip reflectivity calculation for direct beams

--- a/quicknxs/ui/ui_main_window.ui
+++ b/quicknxs/ui/ui_main_window.ui
@@ -600,10 +600,16 @@
               <property name="text">
                <string>Sample size:</string>
               </property>
+	      <property name="visible">
+		<bool>false</bool>
+	      </property>
              </widget>
             </item>
             <item row="9" column="2">
-             <widget class="QDoubleSpinBox" name="sample_size_spinbox">
+              <widget class="QDoubleSpinBox" name="sample_size_spinbox">
+		<property name="visible">
+		  <bool>false</bool>
+		</property>
               <property name="suffix">
                <string> mm</string>
               </property>
@@ -623,6 +629,9 @@
               <property name="text">
                <string>Bandwidth:</string>
               </property>
+	      <property name="visible">
+		<bool>false</bool>
+	      </property>
              </widget>
             </item>
             <item row="10" column="2">
@@ -630,6 +639,9 @@
               <property name="toolTip">
                <string>Bandwidth to use to select the TOF range when loading data.</string>
               </property>
+	      <property name="visible">
+		<bool>false</bool>
+	      </property>
               <property name="suffix">
                <string> A</string>
               </property>


### PR DESCRIPTION
## Description of work:
The `Sample Size` and `Bandwidth` configurations are not currently in use, though the CIS claims will likely be used again in the future. This adds a visibility property set to `false` for each.

Check all that apply:
- [ ] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: [8231: [QuickNXS] Remove obsolete options Sample size and Bandwidth](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8231)
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))
Follow the standard build process and observe the fields are gone.

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
