### PR TITLE
Fix load when PVs missing

### DIFF
--- a/quicknxs/interfaces/data_handling/instrument.py
+++ b/quicknxs/interfaces/data_handling/instrument.py
@@ -265,18 +265,13 @@ class Instrument(object):
 
             # Remove workspaces with too few events
             _path_xs_list = remove_low_event_workspaces(_path_xs_list, configuration.nbr_events_min)
-            print("cross_section_id" in _path_xs_list[0].getRun())
 
             if configuration is not None and configuration.apply_deadtime:
-                print("Loading error events")
                 # Load error events from the bank_error_events entry
                 err_ws = api.LoadErrorEventsNexus(path)
-                print("loaded")
                 # Split error events by cross-section for compatibility with normal events
                 if _use_slow_flipper_log:
                     _err_list = self.dummy_filter_cross_sections(err_ws, name_prefix=temp_workspace_root_name + "_err")
-                    print("processed")
-                    # print(_err_list)
                 else:
                     _err_list = api.MRFilterCrossSections(
                         InputWorkspace=err_ws,
@@ -289,18 +284,12 @@ class Instrument(object):
 
                 path_xs_list = []
                 # Apply dead-time correction for each cross-section workspace
-                print(len(_path_xs_list))
-                print("cross_section_id" in _path_xs_list[0].getRun())
-
                 for ws in _path_xs_list:
-                    print("   trying", str(ws))
                     xs_name = ws.getRun()["cross_section_id"].value
-                    print("   ", str(xs_name))
                     if not xs_name == "unfiltered":
                         # Find the related workspace in with error events
                         is_found = False
                         for err_ws in _err_list:
-                            print("test")
                             if err_ws.getRun()["cross_section_id"].value == xs_name:
                                 is_found = True
                                 _ws = apply_dead_time_correction(ws, configuration, error_ws=err_ws)
@@ -336,7 +325,6 @@ class Instrument(object):
                 LogType="String",
             )
 
-        print("EXIT")
         return xs_list
 
     @classmethod

--- a/quicknxs/interfaces/data_handling/instrument.py
+++ b/quicknxs/interfaces/data_handling/instrument.py
@@ -271,12 +271,12 @@ class Instrument(object):
                 print("Loading error events")
                 # Load error events from the bank_error_events entry
                 err_ws = api.LoadErrorEventsNexus(path)
-                print('loaded')
+                print("loaded")
                 # Split error events by cross-section for compatibility with normal events
                 if _use_slow_flipper_log:
-                    _err_list = self.dummy_filter_cross_sections(err_ws, name_prefix=temp_workspace_root_name+'_err')
-                    print('processed')
-                    #print(_err_list)
+                    _err_list = self.dummy_filter_cross_sections(err_ws, name_prefix=temp_workspace_root_name + "_err")
+                    print("processed")
+                    # print(_err_list)
                 else:
                     _err_list = api.MRFilterCrossSections(
                         InputWorkspace=err_ws,
@@ -284,8 +284,8 @@ class Instrument(object):
                         AnaState=self.ana_state,
                         PolVeto=self.pol_veto,
                         AnaVeto=self.ana_veto,
-                        CrossSectionWorkspaces="%s_err_entry" % temp_workspace_root_name+'_err',
-                    )                  
+                        CrossSectionWorkspaces="%s_err_entry" % temp_workspace_root_name + "_err",
+                    )
 
                 path_xs_list = []
                 # Apply dead-time correction for each cross-section workspace
@@ -293,14 +293,14 @@ class Instrument(object):
                 print("cross_section_id" in _path_xs_list[0].getRun())
 
                 for ws in _path_xs_list:
-                    print('   trying', str(ws))
+                    print("   trying", str(ws))
                     xs_name = ws.getRun()["cross_section_id"].value
                     print("   ", str(xs_name))
                     if not xs_name == "unfiltered":
                         # Find the related workspace in with error events
                         is_found = False
                         for err_ws in _err_list:
-                            print('test')
+                            print("test")
                             if err_ws.getRun()["cross_section_id"].value == xs_name:
                                 is_found = True
                                 _ws = apply_dead_time_correction(ws, configuration, error_ws=err_ws)

--- a/quicknxs/interfaces/data_handling/instrument.py
+++ b/quicknxs/interfaces/data_handling/instrument.py
@@ -244,7 +244,7 @@ class Instrument(object):
         for path in fp_instance.single_paths:
             ws = api.LoadEventNexus(Filename=path, OutputWorkspace="raw_events")
 
-            # If the meta data is corrupted and we are missing analyzer/polarizer data, use the 
+            # If the meta data is corrupted and we are missing analyzer/polarizer data, use the
             # simple filtering.
             missing_keys = any(key not in ws.getRun() for key in [self.pol_state, self.ana_state])
             if missing_keys:
@@ -262,7 +262,7 @@ class Instrument(object):
                     AnaVeto=self.ana_veto,
                     CrossSectionWorkspaces="%s_entry" % temp_workspace_root_name,
                 )
-                
+
             # Remove workspaces with too few events
             _path_xs_list = remove_low_event_workspaces(_path_xs_list, configuration.nbr_events_min)
             if configuration is not None and configuration.apply_deadtime:


### PR DESCRIPTION
It happens too often that during changing the configuration of the instrument, PV related to the state of the analyzer or polarizer are missing. In this case the load fails because of the meta data is incomplete. In 95% of the cases it's a case where we are not measuring a polarized state and the device is removed and the PVs not set properly.

This PR does a number of things:

- It falls back to another method of parsing the events which work in nearly all cases, but is just slower.
- It also makes the way we deal with the dead time correction uniform (it was previously ignored for this second filtering type).