### PR TITLE
Fix test condition for PVs

### DIFF
--- a/quicknxs/interfaces/data_handling/instrument.py
+++ b/quicknxs/interfaces/data_handling/instrument.py
@@ -246,7 +246,11 @@ class Instrument(object):
 
             # If the meta data is corrupted and we are missing analyzer/polarizer data, use the
             # simple filtering.
-            missing_keys = any(key not in event_ws.getRun() for key in [self.pol_state, self.ana_state])
+            polarizer = event_ws.getRun().getProperty("Polarizer").value[0]
+            analyzer = event_ws.getRun().getProperty("Analyzer").value[0]
+            missing_keys = (polarizer > 0 and self.pol_state not in event_ws.getRun()) or \
+            (analyzer > 0 and self.ana_state not in event_ws.getRun())
+
             if missing_keys:
                 _use_slow_flipper_log = True
                 print("\n\nMISSING POLARIZER/ANALYZER META-DATA: USING SLOW LOGS\n\n")


### PR DESCRIPTION
Small mod to the check done to verify that all analyzer/polarizer PVs are present before filtering.
The analyzer/polarizer state PVs only need to be present if the corresponding analyzer/polarizer is present (value > 0).