### PR TITLE
Tweak PV check

### DIFF
--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -244,7 +244,11 @@ class Instrument(object):
 
             # If the meta data is corrupted and we are missing analyzer/polarizer data, use the
             # simple filtering.
-            missing_keys = any(key not in event_ws.getRun() for key in [self.pol_state, self.ana_state])
+            polarizer = event_ws.getRun().getProperty("Polarizer").value[0]
+            analyzer = event_ws.getRun().getProperty("Analyzer").value[0]
+            missing_keys = (polarizer > 0 and self.pol_state not in event_ws.getRun()) or \
+            (analyzer > 0 and self.ana_state not in event_ws.getRun())
+
             if missing_keys:
                 _use_slow_flipper_log = True
                 print("\n\nMISSING POLARIZER/ANALYZER META-DATA: USING SLOW LOGS\n\n")

--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -246,8 +246,9 @@ class Instrument(object):
             # simple filtering.
             polarizer = event_ws.getRun().getProperty("Polarizer").value[0]
             analyzer = event_ws.getRun().getProperty("Analyzer").value[0]
-            missing_keys = (polarizer > 0 and self.pol_state not in event_ws.getRun()) or \
-            (analyzer > 0 and self.ana_state not in event_ws.getRun())
+            missing_keys = (polarizer > 0 and self.pol_state not in event_ws.getRun()) or (
+                analyzer > 0 and self.ana_state not in event_ws.getRun()
+            )
 
             if missing_keys:
                 _use_slow_flipper_log = True


### PR DESCRIPTION
The check for analyzer/polarizer PVs was adjusted to reflect the fact that the analyzer/polarizer state PVs only need to exist when the corresponding analyzer/polarizer is used.