### PR TITLE
Fix icons path in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,1 @@
-include README.md
-include quicknxs/*
-recursive-include quicknxs/icons *.png *.svg *.ico
+recursive-include src/quicknxs/icons *.png *.svg *.ico

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include src/quicknxs/icons *.png *.svg *.ico
+recursive-include src/quicknxs/icons *.png *.svg *.ico *.pdf *.qrc


### PR DESCRIPTION
## Description of work:
Corrects the `icons/` path for work done as part of renaming the repository, having moved the package to `src/`. The anaconda package will now include the icons.

Check all that apply:
- [ ] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: [9006: [QuickNXS] Leftovers from the Renaming Event](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9006)
- Links to related issues or pull requests:


# Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
