### PR TITLE
Upgrade mantid to 6.12

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Check all that apply:
 - Links to related issues or pull requests:
 
 
-# Manual test for the reviewer
+# :warning: Manual test for the reviewer
 ([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))
 
 # Check list for the reviewer

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - versioningit
 
   run:
-    - mantid=6.10.0
+    - mantid=6.12.0
     - matplotlib
     - qtpy
     - qt>=5.12,<6

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,14 +5,15 @@ Release Notes
 =============
 Notes for major and minor releases. Notes for Patch releases are deferred.
 
-v4.2.0
-------
-(date of release, format YYYY-MM-DD)
+.. v4.2.0
+.. ------
+.. (date of release, format YYYY-MM-DD)
 
-**Of interest to the User**:
+.. **Of interest to the User**:
 
+.. - PR #141: Update Mantid version to 6.12
 
-**Of interest to the Developer:**
+.. **Of interest to the Developer:**
 
 
 v4.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,8 @@ name: quicknxs
 channels:
     - mantid/label/main
     - conda-forge
-    - default
 dependencies:
-- mantidworkbench=6.10.0
+- mantidworkbench=6.12.0
 - anaconda-client
 - boa
 - codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quicknxs"
 description = "Magnetic Reflectivity Reduction"
 dynamic = ["version"]
 requires-python = ">=3.10"
-dependencies = ["mantid>=6.10", "matplotlib", "qtpy"]
+dependencies = ["mantid>=6.12", "matplotlib", "qtpy"]
 license = { text = "Apache-2.0" }
 keywords = ["neutrons", "quicknxs", "magnetic reflectivity"]
 readme = "README.md"

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -519,7 +519,9 @@ class MPLWidget(QtWidgets.QWidget):
             self.cplot.set_extent(opts["extent"])
 
     def legend(self, *args, **opts):
-        return self.canvas.ax.legend(*args, **opts)
+        handles, labels = self.canvas.ax.get_legend_handles_labels()
+        if labels:
+            return self.canvas.ax.legend(*args, **opts)
 
     def adjust(self, **adjustment):
         return self.canvas.fig.subplots_adjust(**adjustment)


### PR DESCRIPTION
## Description of work:

Move from mantid 6.10 to 6.12 to fix the security vulnerability affecting the mantid dependency `libcurl`, we need to move:

**libcurl 7.9.1  -->  8.9.1**

From the CI job step that creates the conda environment:
```
libcurl-8.12.1             |       h332b0f4_0         417 KB  conda-forge
```

I tested the QuickNXS GUI and didn't see any errors, but this should be tested by the CIS to make sure there are no hidden errors.

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] ~~updated documentation~~
- [x] Source added/refactored
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Story 9493: [Cyber] [QuickNXS] Remediation](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9493)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Test the normal workflows of loading files, loading reduced data files, changing parameters and reducing data.

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
