### PR TITLE
Handle loading of unpolarized runs

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 .. **Of interest to the User**:
 
 .. - PR #143: Modify behavior of peak finder settings
+.. - PR #149: Fix error when loading unpolarized runs with both `Analyzer` and `Polarizer` = 0
 
 .. **Of interest to the Developer:**
 

--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -27,6 +27,8 @@ from quicknxs.interfaces.data_handling.filepath import FilePath
 h = 6.626e-34  # m^2 kg s^-1
 m = 1.675e-27  # kg
 
+UNPOLARIZED_XS_LABEL = "Off_Off"
+
 
 def get_cross_section_label(ws, entry_name):
     """
@@ -259,10 +261,10 @@ class Instrument(object):
             if _use_slow_flipper_log:
                 _path_xs_list = self.dummy_filter_cross_sections(event_ws, name_prefix=temp_workspace_root_name)
             elif unpolarized:
+                _ws = api.CloneWorkspace(event_ws, OutputWorkspace=f"{temp_workspace_root_name}_entry")
                 # add the expected sample log
-                event_ws.getRun()["cross_section_id"] = "Off_Off"
-                api.RenameWorkspace(str(event_ws), "%s_entry" % temp_workspace_root_name)
-                _path_xs_list = [event_ws]
+                _ws.getRun()["cross_section_id"] = UNPOLARIZED_XS_LABEL
+                _path_xs_list = [_ws]
             else:
                 _path_xs_list = api.MRFilterCrossSections(
                     InputWorkspace=event_ws,
@@ -282,6 +284,11 @@ class Instrument(object):
                 # Split error events by cross-section for compatibility with normal events
                 if _use_slow_flipper_log:
                     _err_list = self.dummy_filter_cross_sections(err_ws, name_prefix=temp_workspace_root_name + "_err")
+                elif unpolarized:
+                    _ws = api.CloneWorkspace(err_ws, OutputWorkspace=f"{temp_workspace_root_name}_err")
+                    # add the expected sample log
+                    _ws.getRun()["cross_section_id"] = UNPOLARIZED_XS_LABEL
+                    _err_list = [_ws]
                 else:
                     _err_list = api.MRFilterCrossSections(
                         InputWorkspace=err_ws,

--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -249,6 +249,8 @@ class Instrument(object):
             missing_keys = (polarizer > 0 and self.pol_state not in event_ws.getRun()) or (
                 analyzer > 0 and self.ana_state not in event_ws.getRun()
             )
+            # If running in unpolarized mode, no filtering is needed
+            unpolarized = polarizer == 0 and analyzer == 0
 
             if missing_keys:
                 _use_slow_flipper_log = True
@@ -256,6 +258,11 @@ class Instrument(object):
 
             if _use_slow_flipper_log:
                 _path_xs_list = self.dummy_filter_cross_sections(event_ws, name_prefix=temp_workspace_root_name)
+            elif unpolarized:
+                # add the expected sample log
+                event_ws.getRun()["cross_section_id"] = "Off_Off"
+                api.RenameWorkspace(str(event_ws), "%s_entry" % temp_workspace_root_name)
+                _path_xs_list = [event_ws]
             else:
                 _path_xs_list = api.MRFilterCrossSections(
                     InputWorkspace=event_ws,

--- a/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
@@ -84,3 +84,14 @@ def test_load_data_nbr_events_min(data_server):
     conf.apply_deadtime = True
     ws_list = conf.instrument.load_data(file_path, conf)
     assert len(ws_list) == 2
+
+
+@pytest.mark.datarepo
+def test_load_unpolarized_data(data_server):
+    """Test load unpolarized data with Polarizer = 0 and Analyzer = 0"""
+    conf = Configuration()
+    file_path = data_server.path_to("REF_M_41889")
+    ws_list = conf.instrument.load_data(file_path, conf)
+    assert len(ws_list) == 1
+    run = ws_list[0].getRun()
+    assert "cross_section_id" in run

--- a/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
@@ -86,10 +86,18 @@ def test_load_data_nbr_events_min(data_server):
     assert len(ws_list) == 2
 
 
+@pytest.mark.parametrize(
+    "apply_deadtime",
+    [
+        False,
+        True,
+    ],
+)
 @pytest.mark.datarepo
-def test_load_unpolarized_data(data_server):
+def test_load_unpolarized_data(data_server, apply_deadtime):
     """Test load unpolarized data with Polarizer = 0 and Analyzer = 0"""
     conf = Configuration()
+    conf.apply_deadtime = apply_deadtime
     file_path = data_server.path_to("REF_M_41889")
     ws_list = conf.instrument.load_data(file_path, conf)
     assert len(ws_list) == 1


### PR DESCRIPTION
## Description of work:

Fix an error with loading unpolarized runs (with logs `Analyzer` and `Polarizer` both = 0). This changes the file loading to add the expected log `cross_section_id` to the workspace but skip filtering by polarization state.

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] ~~updated documentation~~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 10897: [QuickNXS] Fail to load old run numbers](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10897)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
