### PR TITLE
Updated font sizes in off spec plots

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,7 +12,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 .. **Of interest to the User**:
 
 .. - PR #143: Modify behavior of peak finder settings
-.. - PR #150: Updated font sizes of plot labels/ticks for off-specular plots 
+.. - PR #150: Updated font sizes of plot labels/ticks for off-specular plots
 
 .. **Of interest to the Developer:**
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,6 +12,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 .. **Of interest to the User**:
 
 .. - PR #143: Modify behavior of peak finder settings
+.. - PR #150: Updated font sizes of plot labels/ticks for off-specular plots 
 
 .. **Of interest to the Developer:**
 

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -560,7 +560,7 @@ class PlotManager(object):
                 plot.set_xlabel("k$_{i,z}$ [Å$^{-1}$]", fontsize=14)
                 plot.set_ylabel("k$_{f,z}$ [Å$^{-1}$]", fontsize=14)
             plot.set_xticks_fontsize(8)
-            plot.set_yticks_fontsize(10)
+            plot.set_yticks_fontsize(8)
             plot.set_title(channel, fontsize=14)
             if plot.cplot is not None:
                 plot.cplot.set_clim([i_min, i_max])

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -547,19 +547,21 @@ class PlotManager(object):
             if self.main_window.ui.kizmkfzVSqz.isChecked():
                 plot.canvas.ax.set_xlim([k_diff_min, k_diff_max])
                 plot.canvas.ax.set_ylim([qz_min, qz_max])
-                plot.set_xlabel("k$_{i,z}$-k$_{f,z}$ [Å$^{-1}$]")
-                plot.set_ylabel("Q$_z$ [Å$^{-1}$]")
+                plot.set_xlabel("k$_{i,z}$-k$_{f,z}$ [Å$^{-1}$]", fontsize=14)
+                plot.set_ylabel("Q$_z$ [Å$^{-1}$]", fontsize=14)
             elif self.main_window.ui.qxVSqz.isChecked():
                 plot.canvas.ax.set_xlim([qx_min, qx_max])
                 plot.canvas.ax.set_ylim([qz_min, qz_max])
-                plot.set_xlabel("Q$_x$ [Å$^{-1}$]")
-                plot.set_ylabel("Q$_z$ [Å$^{-1}$]")
+                plot.set_xlabel("Q$_x$ [Å$^{-1}$]", fontsize=14)
+                plot.set_ylabel("Q$_z$ [Å$^{-1}$]", fontsize=14)
             else:
                 plot.canvas.ax.set_xlim([ki_z_min, ki_z_max])
                 plot.canvas.ax.set_ylim([kf_z_min, kf_z_max])
-                plot.set_xlabel("k$_{i,z}$ [Å$^{-1}$]")
-                plot.set_ylabel("k$_{f,z}$ [Å$^{-1}$]")
-            plot.set_title(channel)
+                plot.set_xlabel("k$_{i,z}$ [Å$^{-1}$]", fontsize=14)
+                plot.set_ylabel("k$_{f,z}$ [Å$^{-1}$]", fontsize=14)
+            plot.set_xticks_fontsize(8)
+            plot.set_yticks_fontsize(10)
+            plot.set_title(channel, fontsize=14)
             if plot.cplot is not None:
                 plot.cplot.set_clim([i_min, i_max])
                 if self.main_window.ui.show_colorbars.isChecked() and plots[i].cbar is None:

--- a/src/quicknxs/interfaces/smooth_dialog.py
+++ b/src/quicknxs/interfaces/smooth_dialog.py
@@ -89,8 +89,8 @@ class SmoothDialog(QtWidgets.QDialog):
             k_diff_max = max(k_diff_max, (ki_z - kf_z)[I > 0].max())
             plot.canvas.ax.set_xlim([k_diff_min, k_diff_max])
             plot.canvas.ax.set_ylim([qz_min, qz_max])
-            plot.set_xlabel("k$_{i,z}$-k$_{f,z}$ [Å$^{-1}$]")
-            plot.set_ylabel("Q$_z$ [Å$^{-1}$]")
+            plot.set_xlabel("k$_{i,z}$-k$_{f,z}$ [Å$^{-1}$]", fontsize=14)
+            plot.set_ylabel("Q$_z$ [Å$^{-1}$]", fontsize=14)
 
             # draw the blue box 5% inside the plot area
             x1 = k_diff_min + (k_diff_max - k_diff_min) * grid_percentage
@@ -120,8 +120,8 @@ class SmoothDialog(QtWidgets.QDialog):
 
             plot.canvas.ax.set_xlim([qx_min, qx_max])
             plot.canvas.ax.set_ylim([qz_min, qz_max])
-            plot.set_xlabel("Q$_x$ [Å$^{-1}$]")
-            plot.set_ylabel("Q$_z$ [Å$^{-1}$]")
+            plot.set_xlabel("Q$_x$ [Å$^{-1}$]", fontsize=14)
+            plot.set_ylabel("Q$_z$ [Å$^{-1}$]", fontsize=14)
 
             # draw the blue box 5% inside the plot area
             x1 = qx_min + (qx_max - qx_min) * grid_percentage
@@ -150,8 +150,8 @@ class SmoothDialog(QtWidgets.QDialog):
 
             plot.canvas.ax.set_xlim([ki_z_min, ki_z_max])
             plot.canvas.ax.set_ylim([kf_z_min, kf_z_max])
-            plot.set_xlabel("k$_{i,z}$ [Å$^{-1}$]")
-            plot.set_ylabel("k$_{f,z}$ [Å$^{-1}$]")
+            plot.set_xlabel("k$_{i,z}$ [Å$^{-1}$]", fontsize=14)
+            plot.set_ylabel("k$_{f,z}$ [Å$^{-1}$]", fontsize=14)
 
             # draw the blue box 5% inside the plot area
             x1 = ki_z_min + (ki_z_max - ki_z_min) * grid_percentage
@@ -171,6 +171,8 @@ class SmoothDialog(QtWidgets.QDialog):
             self.ui.sigmasCoupled.setChecked(True)
             self.ui.sigmaX.setValue(sigma_x)
             self.ui.sigmaY.setValue(sigma_y)
+        plot.set_xticks_fontsize(8)
+        plot.set_yticks_fontsize(8)
         if plot.cplot is not None:
             plot.cplot.set_clim([1e-6, 1.0])
         self.rect_region = Line2D([x1, x1, x2, x2, x1], [y1, y2, y2, y1, y1])

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -488,7 +488,7 @@ class MPLWidget(QtWidgets.QWidget):
 
     def set_ylabel(self, label, fontsize=None):
         return self.canvas.ax.set_ylabel(label, fontsize=fontsize)
-    
+
     def set_xticks_fontsize(self, fontsize):
         for label in self.canvas.ax.get_xticklabels():
             label.set_fontsize(fontsize)
@@ -496,7 +496,6 @@ class MPLWidget(QtWidgets.QWidget):
     def set_yticks_fontsize(self, fontsize):
         for label in self.canvas.ax.get_yticklabels():
             label.set_fontsize(fontsize)
-
 
     def set_xscale(self, scale):
         try:

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -480,14 +480,23 @@ class MPLWidget(QtWidgets.QWidget):
             self.update(data, **opts)
         return self.cplot
 
-    def set_title(self, new_title):
-        return self.canvas.ax.title.set_text(new_title)
+    def set_title(self, new_title, fontsize=None):
+        return self.canvas.ax.set_title(new_title, fontsize=fontsize)
 
-    def set_xlabel(self, label):
-        return self.canvas.ax.set_xlabel(label)
+    def set_xlabel(self, label, fontsize=None):
+        return self.canvas.ax.set_xlabel(label, fontsize=fontsize)
 
-    def set_ylabel(self, label):
-        return self.canvas.ax.set_ylabel(label)
+    def set_ylabel(self, label, fontsize=None):
+        return self.canvas.ax.set_ylabel(label, fontsize=fontsize)
+    
+    def set_xticks_fontsize(self, fontsize):
+        for label in self.canvas.ax.get_xticklabels():
+            label.set_fontsize(fontsize)
+
+    def set_yticks_fontsize(self, fontsize):
+        for label in self.canvas.ax.get_yticklabels():
+            label.set_fontsize(fontsize)
+
 
     def set_xscale(self, scale):
         try:


### PR DESCRIPTION
## Description of work:
Added/modified functions in MPLWidget to be able to set fontsize of x/y
labels, ticks, and plot title for off spec plotting

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9368
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Load run 38198 and run reduction with both off-specular raw and binned boxes checked. Click the Off-Specular tab and verify the plot labels font sizes are acceptable. Below is what it should look like now. If I made the x ticks font size bigger, the values would start to overlap.

![image](https://github.com/user-attachments/assets/6c0a5774-3134-44f4-9c5f-0f0463069295)


# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
