### PR TITLE
Add `mr_reduction` as a dependency

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          channels: mantid/label/main,conda-forge,defaults
+          channels: neutrons/label/main,mantid/label/main,oncat,conda-forge
           python-version: '3.10'
           miniconda-version: latest
           mamba-version: "*"
@@ -31,7 +31,8 @@ jobs:
       - name: Build Conda package
         run: |
           cd conda.recipe
-          VERSION=$(versioningit ../) conda mambabuild --output-folder . . -c mantid
+          CHANNELS="--channel neutrons/label/main --channel mantid/label/main --channel oncat --channel conda-forge"
+          VERSION=$(versioningit ../) conda mambabuild $CHANNELS --output-folder . .
           conda verify noarch/quicknxs-*.tar.bz2
 
       - name: Deploy to Anaconda

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          channels: mantid/label/main,conda-forge,defaults
+          channels: neutrons/label/main,mantid/label/main,oncat,conda-forge
           python-version: '3.10'
           miniconda-version: latest
           mamba-version: "*"
@@ -81,5 +81,6 @@ jobs:
       - name: Build Conda package
         run: |
           cd conda.recipe
-          VERSION=$(versioningit ../) conda mambabuild --output-folder . . -c mantid
+          CHANNELS="--channel neutrons/label/main --channel mantid/label/main --channel oncat --channel conda-forge"
+          VERSION=$(versioningit ../) conda mambabuild $CHANNELS --output-folder . .
           conda verify noarch/quicknxs-*.tar.bz2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          channels: mantid/label/main,conda-forge,defaults
+          channels: neutrons/label/main,mantid/label/main,oncat,conda-forge
           python-version: '3.10'
           miniconda-version: latest
           mamba-version: "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
           miniconda-version: latest
           mamba-version: "*"
           environment-file: environment.yml
-          lfs: true
-          submodules: recursive
+      - name: Dependencies synced
+        run: python scripts/check_dependencies_sync.py
       - name: Generate cache key for submodule
         id: generate-cache-key
         run: |
@@ -72,8 +72,6 @@ jobs:
           miniconda-version: latest
           mamba-version: "*"
           environment-file: environment.yml
-          lfs: true
-          submodules: recursive
       - name: Build Wheel
         run: |
           python -m build --wheel --no-isolation

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,16 +32,11 @@ requirements:
 
   build:
     - mr_reduction
-    - matplotlib
     - setuptools
-    - qtpy
     - versioningit
 
   run:
     - mr_reduction=2.2.0
-    - matplotlib
-    - qtpy
-    - qt>=5.12,<6
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -31,14 +31,14 @@ requirements:
     - versioningit
 
   build:
-    - mantid
+    - mr_reduction
     - matplotlib
     - setuptools
     - qtpy
     - versioningit
 
   run:
-    - mantid=6.12.0
+    - mr_reduction=2.2.0
     - matplotlib
     - qtpy
     - qt>=5.12,<6

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -19,6 +19,8 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 .. **Of interest to the Developer:**
 
 .. - PR #143: Settings from peak finder are now global attributes of Configuration class
+.. - PR #151: `mr_reduction` is added as a dependency and, as a consequence, `mantid` is removed as
+     an explicit dependency
 
 v4.3.0
 ------

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,11 @@
 name: quicknxs
 channels:
+    - neutrons/label/main
     - mantid/label/main
+    - oncat
     - conda-forge
 dependencies:
-- mantidworkbench=6.12.0
+- mr_reduction=2.2.0
 - anaconda-client
 - boa
 - codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quicknxs"
 description = "Magnetic Reflectivity Reduction"
 dynamic = ["version"]
 requires-python = ">=3.10"
-dependencies = ["mr_reduction>=2.2", "matplotlib", "qtpy"]
+dependencies = ["mr_reduction>=2.2"]
 license = { text = "Apache-2.0" }
 keywords = ["neutrons", "quicknxs", "magnetic reflectivity"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quicknxs"
 description = "Magnetic Reflectivity Reduction"
 dynamic = ["version"]
 requires-python = ">=3.10"
-dependencies = ["mr_reduction>=2.2"]
+dependencies = ["mr_reduction==2.2.0"]
 license = { text = "Apache-2.0" }
 keywords = ["neutrons", "quicknxs", "magnetic reflectivity"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "quicknxs"
 description = "Magnetic Reflectivity Reduction"
 dynamic = ["version"]
 requires-python = ">=3.10"
-dependencies = ["mantid>=6.12", "matplotlib", "qtpy"]
+dependencies = ["mr_reduction>=2.2", "matplotlib", "qtpy"]
 license = { text = "Apache-2.0" }
 keywords = ["neutrons", "quicknxs", "magnetic reflectivity"]
 readme = "README.md"

--- a/scripts/check_dependencies_sync.py
+++ b/scripts/check_dependencies_sync.py
@@ -1,0 +1,33 @@
+import logging
+import os
+import re
+import sys
+
+script_dir: str = os.path.dirname(os.path.realpath(__file__))
+repo_dir: str = os.path.dirname(script_dir)
+
+
+def check_dependencies_synced():
+    r"""Check that the dependencies of environment.yml, meta.yaml and pyproject.toml are in sync"""
+
+    conda_env = open(os.path.join(repo_dir, "environment.yml"), "r").read()
+    pyproject_toml = open(os.path.join(repo_dir, "pyproject.toml"), "r").read()
+    conda_recipe = open(os.path.join(repo_dir, "conda.recipe", "meta.yaml"), "r").read()
+
+    # check for MagnetismReflectometer versions
+    mr_conda = re.search(r"mr_reduction[>=<]+(\d+(?:\.\d+)*)", conda_env).group(1)
+    mr_pyproject = re.search(r"mr_reduction[>=<]+(\d+(?:\.\d+)*)", pyproject_toml).group(1)
+    mr_recipe = re.search(r"mr_reduction[>=<]+(\d+(?:\.\d+)*)", conda_recipe).group(1)
+    if mr_conda != mr_pyproject:
+        raise RuntimeError("environment.yml and pyproject.toml ask different versions of mr_reduction")
+    if mr_conda != mr_recipe:
+        raise RuntimeError("environment.yml and meta.yaml ask different versions of mr_reduction")
+
+
+if __name__ == "__main__":
+    try:
+        check_dependencies_synced()
+    except RuntimeError as e:
+        logging.error(f"{e}")
+        sys.exit(1)
+    sys.exit(0)

--- a/src/quicknxs/gui.py
+++ b/src/quicknxs/gui.py
@@ -37,11 +37,13 @@ import matplotlib
 matplotlib.use("Qt5Agg")
 
 import mantid
+import mr_reduction
 
 import quicknxs
 
 print("##################################################")
 print("# QuickNXS %s " % quicknxs.__version__)
+print("#    with mr_reduction: %s " % mr_reduction.__version__)
 print("#    with Mantid: %s " % mantid.__version__)
 print("##################################################")
 

--- a/src/quicknxs/interfaces/data_handling/quicknxs_io.py
+++ b/src/quicknxs/interfaces/data_handling/quicknxs_io.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 import mantid
+import mr_reduction
 import numpy as np
 
 from quicknxs import __version__
@@ -100,6 +101,7 @@ def write_reflectivity_header(
 
     fd = open(output_path, "w")
     fd.write("# Datafile created by QuickNXS %s\n" % __version__)
+    fd.write("# Datafile created using mr_reduction %s\n" % mr_reduction.__version__)
     fd.write("# Datafile created using Mantid %s\n" % mantid.__version__)
     fd.write("# Date: %s\n" % time.strftime("%Y-%m-%d %H:%M:%S"))
     fd.write("# Type: Specular\n")


### PR DESCRIPTION
## Description of work:

Update conda environment and recipe to add `mr_reduction` as a dependency, in order to use the ORSO saving functionality. Since Mantid is a dependency of `mr_reduction`, remove Mantid as an explicit dependency.

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] ~~updated documentation~~
- [x] Source added/refactored
- [ ] ~~Added unit tests~~
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Story 6004: [QuickNXS] Functionality to save ORSO formatted files as output by QuickNXS](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6004)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Run `quicknxs-gui` and verify that the right versions are printed:

```
##################################################
# QuickNXS 4.5.0.dev2+d202504231750 
#    with mr_reduction: 2.2.0 
#    with Mantid: 6.12.0 
##################################################
```

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
