### PR TITLE
Save ORSO output

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 
 .. **Of interest to the User**:
 .. - PR #158: output the specular data also in ORSO format
+.. - PR #156: binned off-specular preview plot shows data for all runs
 
 .. **Of interest to the Developer:**
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,13 +10,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 .. (date of release, format YYYY-MM-DD)
 
 .. **Of interest to the User**:
-   - PR #156: binned off-specular preview plot shows data for all runs
-.. - PR #153: Plots Intensity (Counts vs. ToF) when a direct beam run is selected.
-.. - PR #152: Github actions - versiongit information from tags
-.. - PR #150: Updated font sizes of plot labels/ticks for off-specular plots
-.. - PR #149: Fix error when loading unpolarized runs with both `Analyzer` and `Polarizer` = 0
-.. - PR #147: Add ability to load v1 (pre-EPICS) Nexus data files
-.. - PR #143: Modify behavior of peak finder settings
+.. - PR #158: output the specular data also in ORSO format
 
 .. **Of interest to the Developer:**
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -12,3 +12,4 @@ User Guide
    binning
    dead_time_correction
    peak_finder
+   reduction

--- a/docs/user/reduction.rst
+++ b/docs/user/reduction.rst
@@ -1,0 +1,21 @@
+.. _reduction:
+
+Reduction
+=========
+
+Reduction Output
+----------------
+
+Output Files
+++++++++++++
+
+After successful reduction using the default settings, the following files are generated in the
+output directory. Below is a list for run peaks 42535_1 and 42536_1. The particular cross-sections
+will depend on the instrument settings, which for these runs turn out to be "Off_Off" and "On_Off".
+
+- **REF_M_42535+42536_peak1_Specular_Off_Off.dat**: combined reflectivity curve for the "Off_Off" cross-section.
+- **REF_M_42535+42536_peak1_Specular_On_Off.dat**: combined reflectivity curve for the "On_Off" cross-section.
+- **REF_M_42535+42536_peak1_Specular_SA.dat**: spin asymmetry (SA) of the combined reflectivity.
+- **REF_M_42535+42536_1_combined.ort**: combined reflectivity curve for all cross-sections for the run peaks (ORSO ASCII format).
+- **REF_M_42535_1.ort**: reflectivity curves for all cross-sections for run peak 42535_1 (ORSO ASCII format).
+- **REF_M_42536_1.ort**: reflectivity curves for all cross-sections for run peak 42536_1 (ORSO ASCII format).

--- a/src/quicknxs/interfaces/configuration.py
+++ b/src/quicknxs/interfaces/configuration.py
@@ -52,6 +52,38 @@ class Configuration(object):
     bck_offset = 5
     force_bck_roi = True
 
+    @classmethod
+    def setup_default_values(cls):
+        """Initialize class variables - only used for testing purposes"""
+        cls.QX_VS_QZ = 0
+        cls.KZI_VS_KZF = 1
+        cls.DELTA_KZ_VS_QZ = 3
+        cls.sample_size = 10
+        cls.use_constant_q = False
+        cls.wl_bandwidth = 3.2
+        cls.do_final_rebin_global = True
+        cls.final_rebin_step_global = -0.01
+        cls.normalize_to_unity = True
+        cls.total_reflectivity_q_cutoff = 0.01
+        cls.global_stitching = False
+        cls.polynomial_stitching = False
+        cls.polynomial_stitching_degree = 3
+        cls.polynomial_stitching_points = 3
+        cls.apply_deadtime = False
+        cls.paralyzable_deadtime = True
+        cls.deadtime_value = 4.2
+        cls.deadtime_tof_step = 100
+        cls.lock_direct_beam_y = False
+        cls.nbr_events_min = 100
+        cls.use_roi = True
+        cls.update_peak_range = False
+        cls.use_peak_finder = False
+        cls.use_low_res_finder = False
+        cls.use_roi_bck = False
+        cls.use_tight_bck = False
+        cls.bck_offset = 5
+        cls.force_bck_roi = True
+
     # TODO: settings may not be needed anymore
     def __init__(self, settings=None):
         self.instrument = Instrument()
@@ -174,38 +206,6 @@ class Configuration(object):
     def bck_roi(self, value):
         self.bck_position = (value[1] + value[0]) / 2.0
         self.bck_width = value[1] - value[0]
-
-    @classmethod
-    def setup_default_values(cls):
-        """Only used for testing purposes"""
-        cls.QX_VS_QZ = 0
-        cls.KZI_VS_KZF = 1
-        cls.DELTA_KZ_VS_QZ = 3
-        cls.sample_size = 10
-        cls.use_constant_q = False
-        cls.wl_bandwidth = 3.2
-        cls.do_final_rebin_global = True
-        cls.final_rebin_step_global = -0.01
-        cls.normalize_to_unity = True
-        cls.total_reflectivity_q_cutoff = 0.01
-        cls.global_stitching = False
-        cls.polynomial_stitching = False
-        cls.polynomial_stitching_degree = 3
-        cls.polynomial_stitching_points = 3
-        cls.apply_deadtime = False
-        cls.paralyzable_deadtime = True
-        cls.deadtime_value = 4.2
-        cls.deadtime_tof_step = 100
-        cls.lock_direct_beam_y = False
-        cls.nbr_events_min = 100
-        cls.use_roi = True
-        cls.update_peak_range = False
-        cls.use_peak_finder = False
-        cls.use_low_res_finder = False
-        cls.use_roi_bck = False
-        cls.use_tight_bck = False
-        cls.bck_offset = 5
-        cls.force_bck_roi = True
 
 
 def get_direct_beam_low_res_roi(data_conf, direct_beam_conf):

--- a/src/quicknxs/interfaces/data_handling/processing_workflow.py
+++ b/src/quicknxs/interfaces/data_handling/processing_workflow.py
@@ -20,8 +20,10 @@ from email.mime.text import MIMEText
 from typing import Dict
 
 import numpy as np
+from mantid.simpleapi import CopyLogs, CreateWorkspace
 from mr_reduction import io_orso
 from mr_reduction.runpeak import RunPeakNumber
+from mr_reduction.types import MantidWorkspace
 
 from quicknxs.interfaces.configuration import Configuration
 from quicknxs.interfaces.data_handling import data_manipulation, gisans, off_specular, quicknxs_io
@@ -179,12 +181,27 @@ class ProcessingWorkflow(object):
             quicknxs_io.write_reflectivity_data(state_output_path, output_data[pol_state], col_names, as_5col=five_cols)
             self.exported_data_files.append(state_output_path)
 
-    def write_orso(self):
+    def write_orso(self, output_data: Dict[str, np.ndarray]):
         """
         Save individual and combined reflectivity curves to ORSO format
         """
         peak_number = self.data_manager.active_reduction_list_index
+        run_list = [str(item.number) for item in self.data_manager.reduction_list]
         output_dir = self.output_options["output_directory"]
+
+        def _create_combined_reflectivity_workspace(_ws: MantidWorkspace, _xs: str):
+            """Create a new workspace with metadata copied from the given workspace and
+            output data for the given cross-section"""
+            output_xs = output_data[_xs]
+            _ws_combined = CreateWorkspace(
+                DataX=output_xs[:, 0],
+                DataY=output_xs[:, 1],
+                DataE=output_xs[:, 2],
+                Dx=output_xs[:, 3],
+                OutputWorkspace=str(ws_first) + "-combined",
+            )
+            CopyLogs(_ws, _ws_combined, MergeStrategy="WipeExisting")
+            return _ws_combined
 
         # Save the individual runs to ORSO
         individual_paths = {}
@@ -196,26 +213,20 @@ class ProcessingWorkflow(object):
             io_orso.save_cross_sections(reflectivity_workspaces, filepath)
             individual_paths[run] = filepath
 
-        # Assemble the list of runs and scaling factors
-        orso_sequence = {}
-        scalings = {}
-        xs = self.data_manager.active_channel.name
-        for nexus_data in self.data_manager.reduction_list:
-            run = str(nexus_data.number)
-            filepath = individual_paths[run]
-            if os.path.isfile(filepath):
-                orso_sequence[run] = filepath
-                # the scaling factor is the same for all cross-sections of a run
-                scalings[run] = nexus_data.cross_sections[xs].configuration.scaling_factor
+        # Assemble the combined reflectivity workspaces
+        combined_reflectivity_workspaces = []
+        cross_sections = self.data_manager.reduction_states
+        for xs in cross_sections:
+            # clone first reflectivity workspace to include metadata
+            ws_first = self.data_manager.reduction_list[0].cross_sections[xs].reflectivity_workspace
+            # replace data with combined reflectivity data
+            ws_combined = _create_combined_reflectivity_workspace(ws_first, xs)
+            combined_reflectivity_workspaces.append(ws_combined)
 
         # Save the combined reflectivity to ORSO
-        combined_filename = f"REF_M_{'+'.join(orso_sequence.keys())}_{peak_number}_combined.ort"
+        combined_filename = f"REF_M_{'+'.join(run_list)}_{peak_number}_combined.ort"
         combined_path = os.path.join(output_dir, combined_filename)
-        io_orso.concatenate_runs(
-            filepath_sequence=orso_sequence,
-            concatenated_filepath=os.path.join(output_dir, combined_path),
-            scaling_factors=scalings,
-        )
+        io_orso.save_cross_sections(combined_reflectivity_workspaces, combined_path)
 
     def specular_reflectivity(self):
         """
@@ -236,7 +247,7 @@ class ProcessingWorkflow(object):
         self.write_quicknxs(output_data, output_file_base)
 
         # ORSO format
-        self.write_orso()
+        self.write_orso(output_data)
 
         # Numpy arrays
         if self.output_options["format_numpy"]:

--- a/src/quicknxs/interfaces/data_handling/processing_workflow.py
+++ b/src/quicknxs/interfaces/data_handling/processing_workflow.py
@@ -182,7 +182,22 @@ class ProcessingWorkflow(object):
 
     def write_orso(self, output_data: Dict[str, np.ndarray]):
         """
-        Save individual and combined reflectivity curves to ORSO format
+        Save individual and combined reflectivity curves to ORSO format.
+
+        This function collects reflectivity data and metadata and saves one individual ORSO ASCII
+        file per run and peak and one combined (stitched) ORSO ASCII file per peak.
+
+        Parameters
+        ----------
+        output_data: Dict[str, np.ndarray]
+            Dictionary of scaled and stitched data where the key is the cross-section name and the
+            value is an array of reflectivity data with shape (number of Q points, 5), where the 5
+            columns are:
+            - Qz: normal momentum transfer
+            - R: reflectivity
+            - dR: reflectivity error
+            - dQz: normal momentum transfer error
+            - theta: scattering angle
         """
         # Save the individual runs to ORSO
         individual_paths = {}
@@ -211,9 +226,9 @@ class ProcessingWorkflow(object):
         combined_reflectivity_workspaces = []
         cross_sections = self.data_manager.reduction_states
         for xs in cross_sections:
-            # clone first reflectivity workspace to include metadata
+            # use the first reflectivity workspace to copy metadata from
             ws_first = self.data_manager.reduction_list[0].cross_sections[xs].reflectivity_workspace
-            # replace data with combined reflectivity data
+            # create a workspace from the stitched reflectivity data and add metadata
             ws_combined = _create_combined_reflectivity_workspace(ws_first, xs)
             combined_reflectivity_workspaces.append(ws_combined)
 

--- a/src/quicknxs/interfaces/data_handling/processing_workflow.py
+++ b/src/quicknxs/interfaces/data_handling/processing_workflow.py
@@ -20,6 +20,8 @@ from email.mime.text import MIMEText
 from typing import Dict
 
 import numpy as np
+from mr_reduction import io_orso
+from mr_reduction.runpeak import RunPeakNumber
 
 from quicknxs.interfaces.configuration import Configuration
 from quicknxs.interfaces.data_handling import data_manipulation, gisans, off_specular, quicknxs_io
@@ -177,6 +179,44 @@ class ProcessingWorkflow(object):
             quicknxs_io.write_reflectivity_data(state_output_path, output_data[pol_state], col_names, as_5col=five_cols)
             self.exported_data_files.append(state_output_path)
 
+    def write_orso(self):
+        """
+        Save individual and combined reflectivity curves to ORSO format
+        """
+        peak_number = self.data_manager.active_reduction_list_index
+        output_dir = self.output_options["output_directory"]
+
+        # Save the individual runs to ORSO
+        individual_paths = {}
+        for nexus_data in self.data_manager.reduction_list:
+            run = str(nexus_data.number)
+            runpeak = RunPeakNumber(run, peak_number)
+            reflectivity_workspaces = nexus_data.get_reflectivity_workspace_group()
+            filepath = os.path.join(output_dir, f"REF_M_{runpeak}.ort")
+            io_orso.save_cross_sections(reflectivity_workspaces, filepath)
+            individual_paths[run] = filepath
+
+        # Assemble the list of runs and scaling factors
+        orso_sequence = {}
+        scalings = {}
+        xs = self.data_manager.active_channel.name
+        for nexus_data in self.data_manager.reduction_list:
+            run = str(nexus_data.number)
+            filepath = individual_paths[run]
+            if os.path.isfile(filepath):
+                orso_sequence[run] = filepath
+                # the scaling factor is the same for all cross-sections of a run
+                scalings[run] = nexus_data.cross_sections[xs].configuration.scaling_factor
+
+        # Save the combined reflectivity to ORSO
+        combined_filename = f"REF_M_{'+'.join(orso_sequence.keys())}_{peak_number}_combined.ort"
+        combined_path = os.path.join(output_dir, combined_filename)
+        io_orso.concatenate_runs(
+            filepath_sequence=orso_sequence,
+            concatenated_filepath=os.path.join(output_dir, combined_path),
+            scaling_factors=scalings,
+        )
+
     def specular_reflectivity(self):
         """
         Retrieve the computed reflectivity and save it to file
@@ -194,6 +234,9 @@ class ProcessingWorkflow(object):
         # QuickNXS format
         output_file_base = self.get_file_name(run_list)
         self.write_quicknxs(output_data, output_file_base)
+
+        # ORSO format
+        self.write_orso()
 
         # Numpy arrays
         if self.output_options["format_numpy"]:

--- a/src/quicknxs/interfaces/data_handling/processing_workflow.py
+++ b/src/quicknxs/interfaces/data_handling/processing_workflow.py
@@ -22,7 +22,6 @@ from typing import Dict
 import numpy as np
 from mantid.simpleapi import CopyLogs, CreateWorkspace
 from mr_reduction import io_orso
-from mr_reduction.runpeak import RunPeakNumber
 from mr_reduction.types import MantidWorkspace
 
 from quicknxs.interfaces.configuration import Configuration
@@ -185,9 +184,14 @@ class ProcessingWorkflow(object):
         """
         Save individual and combined reflectivity curves to ORSO format
         """
-        peak_number = self.data_manager.active_reduction_list_index
-        run_list = [str(item.number) for item in self.data_manager.reduction_list]
-        output_dir = self.output_options["output_directory"]
+        # Save the individual runs to ORSO
+        individual_paths = {}
+        for nexus_data in self.data_manager.reduction_list:
+            run = str(nexus_data.number)
+            reflectivity_workspaces = nexus_data.get_reflectivity_workspace_group()
+            filepath = self.get_file_name([run], "all", "ort")
+            io_orso.save_cross_sections(reflectivity_workspaces, filepath)
+            individual_paths[run] = filepath
 
         def _create_combined_reflectivity_workspace(_ws: MantidWorkspace, _xs: str):
             """Create a new workspace with metadata copied from the given workspace and
@@ -203,16 +207,6 @@ class ProcessingWorkflow(object):
             CopyLogs(_ws, _ws_combined, MergeStrategy="WipeExisting")
             return _ws_combined
 
-        # Save the individual runs to ORSO
-        individual_paths = {}
-        for nexus_data in self.data_manager.reduction_list:
-            run = str(nexus_data.number)
-            runpeak = RunPeakNumber(run, peak_number)
-            reflectivity_workspaces = nexus_data.get_reflectivity_workspace_group()
-            filepath = os.path.join(output_dir, f"REF_M_{runpeak}.ort")
-            io_orso.save_cross_sections(reflectivity_workspaces, filepath)
-            individual_paths[run] = filepath
-
         # Assemble the combined reflectivity workspaces
         combined_reflectivity_workspaces = []
         cross_sections = self.data_manager.reduction_states
@@ -224,8 +218,8 @@ class ProcessingWorkflow(object):
             combined_reflectivity_workspaces.append(ws_combined)
 
         # Save the combined reflectivity to ORSO
-        combined_filename = f"REF_M_{'+'.join(run_list)}_{peak_number}_combined.ort"
-        combined_path = os.path.join(output_dir, combined_filename)
+        run_list = [str(item.number) for item in self.data_manager.reduction_list]
+        combined_path = self.get_file_name(run_list, "all", "ort")
         io_orso.save_cross_sections(combined_reflectivity_workspaces, combined_path)
 
     def specular_reflectivity(self):

--- a/src/quicknxs/interfaces/data_handling/processing_workflow.py
+++ b/src/quicknxs/interfaces/data_handling/processing_workflow.py
@@ -198,7 +198,7 @@ class ProcessingWorkflow(object):
                 DataY=output_xs[:, 1],
                 DataE=output_xs[:, 2],
                 Dx=output_xs[:, 3],
-                OutputWorkspace=str(ws_first) + "-combined",
+                OutputWorkspace=str(_ws) + "-combined",
             )
             CopyLogs(_ws, _ws_combined, MergeStrategy="WipeExisting")
             return _ws_combined

--- a/test/integration/quicknxs/interfaces/data_handling/test_processing_workflow.py
+++ b/test/integration/quicknxs/interfaces/data_handling/test_processing_workflow.py
@@ -12,6 +12,7 @@ from quicknxs.interfaces.data_manager import DataManager
 @pytest.mark.datarepo
 def test_orso_output(data_server, tmpdir):
     """Test saving reflectivity curves to ORSO"""
+    Configuration.setup_default_values()
     conf = Configuration()
     conf.cut_first_n_points = 0
     conf.cut_last_n_points = 0

--- a/test/unit/quicknxs/interfaces/data_handling/test_processing_workflow.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_processing_workflow.py
@@ -2,6 +2,7 @@ import os
 from copy import deepcopy
 
 import pytest
+from orsopy.fileio import load_orso
 
 from quicknxs.interfaces.configuration import Configuration
 from quicknxs.interfaces.data_handling.processing_workflow import DEFAULT_OPTIONS, ProcessingWorkflow
@@ -12,6 +13,8 @@ from quicknxs.interfaces.data_manager import DataManager
 def test_orso_output(data_server, tmpdir):
     """Test saving reflectivity curves to ORSO"""
     conf = Configuration()
+    conf.cut_first_n_points = 0
+    conf.cut_last_n_points = 0
     manager = DataManager(data_server.directory)
     output_options = deepcopy(DEFAULT_OPTIONS)
     output_options["output_directory"] = str(tmpdir)
@@ -30,29 +33,25 @@ def test_orso_output(data_server, tmpdir):
     # add a second peak
     manager.add_additional_reduction_list(2)
 
+    # make the two peaks different by cutting data points from the first run of the first peak
+    first_state = manager.reduction_states[0]
+    manager.reduction_list[0].cross_sections[first_state].configuration.cut_last_n_points = 8
+
     # write output files for the two peaks
     for peak_index in manager.peak_reduction_lists.keys():
         manager.set_active_reduction_list_index(peak_index)
         manager.set_active_data_from_reduction_list(0)
         pw.specular_reflectivity()
 
-    # check the output files
-    for file in [
-        "REF_M_42112_1.ort",
-        "REF_M_42112_2.ort",
-        "REF_M_42113_1.ort",
-        "REF_M_42113_2.ort",
-        "REF_M_42112+42113_1_combined.ort",
-        "REF_M_42112+42113_2_combined.ort",
-        "REF_M_42112+42113_peak1_Specular_all.py",
-        "REF_M_42112+42113_peak2_Specular_all.py",
-        "REF_M_42112+42113_peak1_Specular_Off_Off.dat",
-        "REF_M_42112+42113_peak1_Specular_Off_On.dat",
-        "REF_M_42112+42113_peak1_Specular_On_Off.dat",
-        "REF_M_42112+42113_peak1_Specular_On_On.dat",
-        "REF_M_42112+42113_peak2_Specular_Off_Off.dat",
-        "REF_M_42112+42113_peak2_Specular_Off_On.dat",
-        "REF_M_42112+42113_peak2_Specular_On_Off.dat",
-        "REF_M_42112+42113_peak2_Specular_On_On.dat",
+    # load ORSO files and check the reflectivity data
+    for file, reflectivity_data_lengths in [
+        ("REF_M_42112_1.ort", [140, 139, 140, 139]),
+        ("REF_M_42112_2.ort", [140, 139, 140, 139]),
+        ("REF_M_42113_1.ort", [136, 139, 123, 140]),
+        ("REF_M_42113_2.ort", [136, 139, 123, 140]),
+        ("REF_M_42112+42113_1_combined.ort", [268, 270, 255, 271]),  # peak 1 - 8 data points removed
+        ("REF_M_42112+42113_2_combined.ort", [276, 278, 263, 279]),  # peak 2 - no data points removed
     ]:
-        assert os.path.isfile(os.path.join(tmpdir, file))
+        datasets = load_orso(os.path.join(tmpdir, file))
+        for i, dataset in enumerate(datasets):
+            assert len(dataset.data) == reflectivity_data_lengths[i]

--- a/test/unit/quicknxs/interfaces/data_handling/test_processing_workflow.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_processing_workflow.py
@@ -45,12 +45,12 @@ def test_orso_output(data_server, tmpdir):
 
     # load ORSO files and check the reflectivity data
     for file, reflectivity_data_lengths in [
-        ("REF_M_42112_1.ort", [140, 139, 140, 139]),
-        ("REF_M_42112_2.ort", [140, 139, 140, 139]),
-        ("REF_M_42113_1.ort", [136, 139, 123, 140]),
-        ("REF_M_42113_2.ort", [136, 139, 123, 140]),
-        ("REF_M_42112+42113_1_combined.ort", [268, 270, 255, 271]),  # peak 1 - 8 data points removed
-        ("REF_M_42112+42113_2_combined.ort", [276, 278, 263, 279]),  # peak 2 - no data points removed
+        ("REF_M_42112_peak1_Specular_all.ort", [140, 139, 140, 139]),
+        ("REF_M_42112_peak2_Specular_all.ort", [140, 139, 140, 139]),
+        ("REF_M_42113_peak1_Specular_all.ort", [136, 139, 123, 140]),
+        ("REF_M_42113_peak2_Specular_all.ort", [136, 139, 123, 140]),
+        ("REF_M_42112+42113_peak1_Specular_all.ort", [268, 270, 255, 271]),  # peak 1 - 8 data points removed
+        ("REF_M_42112+42113_peak2_Specular_all.ort", [276, 278, 263, 279]),  # peak 2 - no data points removed
     ]:
         datasets = load_orso(os.path.join(tmpdir, file))
         for i, dataset in enumerate(datasets):

--- a/test/unit/quicknxs/interfaces/data_handling/test_processing_workflow.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_processing_workflow.py
@@ -1,0 +1,58 @@
+import os
+from copy import deepcopy
+
+import pytest
+
+from quicknxs.interfaces.configuration import Configuration
+from quicknxs.interfaces.data_handling.processing_workflow import DEFAULT_OPTIONS, ProcessingWorkflow
+from quicknxs.interfaces.data_manager import DataManager
+
+
+@pytest.mark.datarepo
+def test_orso_output(data_server, tmpdir):
+    """Test saving reflectivity curves to ORSO"""
+    conf = Configuration()
+    manager = DataManager(data_server.directory)
+    output_options = deepcopy(DEFAULT_OPTIONS)
+    output_options["output_directory"] = str(tmpdir)
+    pw = ProcessingWorkflow(manager, output_options)
+
+    def _load_to_reduction_list(filename):
+        """Loads a Nexus file and adds it to the reduction list"""
+        file_path = data_server.path_to(filename)
+        manager.load(file_path, conf)
+        manager.add_active_to_reduction()
+
+    # load two runs
+    _load_to_reduction_list("REF_M_42112.nxs.h5")
+    _load_to_reduction_list("REF_M_42113.nxs.h5")
+
+    # add a second peak
+    manager.add_additional_reduction_list(2)
+
+    # write output files for the two peaks
+    for peak_index in manager.peak_reduction_lists.keys():
+        manager.set_active_reduction_list_index(peak_index)
+        manager.set_active_data_from_reduction_list(0)
+        pw.specular_reflectivity()
+
+    # check the output files
+    for file in [
+        "REF_M_42112_1.ort",
+        "REF_M_42112_2.ort",
+        "REF_M_42113_1.ort",
+        "REF_M_42113_2.ort",
+        "REF_M_42112+42113_1_combined.ort",
+        "REF_M_42112+42113_2_combined.ort",
+        "REF_M_42112+42113_peak1_Specular_all.py",
+        "REF_M_42112+42113_peak2_Specular_all.py",
+        "REF_M_42112+42113_peak1_Specular_Off_Off.dat",
+        "REF_M_42112+42113_peak1_Specular_Off_On.dat",
+        "REF_M_42112+42113_peak1_Specular_On_Off.dat",
+        "REF_M_42112+42113_peak1_Specular_On_On.dat",
+        "REF_M_42112+42113_peak2_Specular_Off_Off.dat",
+        "REF_M_42112+42113_peak2_Specular_Off_On.dat",
+        "REF_M_42112+42113_peak2_Specular_On_Off.dat",
+        "REF_M_42112+42113_peak2_Specular_On_On.dat",
+    ]:
+        assert os.path.isfile(os.path.join(tmpdir, file))


### PR DESCRIPTION
## Description of work:

When reduction output is saved, save also individual and combined reflectivity curves to ORSO format.

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [ ] ~~Added unit tests~~
- [x] Added integration tests

**References:**
- Links to IBM EWM items: [Story 6004: [QuickNXS] Functionality to save ORSO formatted files as output by QuickNXS](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6004)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

1. Start QuickNXS and load some data, e.g. runs 42535 and 42536, and add them to the reduction list.
2. Click the button "Reduce...".
3. Verify that the output directory contains the following ORSO files:
   - `REF_M_42535_1.ort`
   - `REF_M_42536_1.ort`
   - `REF_M_42535+42536_1_combined.ort`

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
