### PR TITLE
Direct Beam Intensity Plot Normalization and Error Bars

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -10,6 +10,7 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 .. (date of release, format YYYY-MM-DD)
 
 .. **Of interest to the User**:
+.. - PR #162: Direct beam intensity plot now uses normalized ROI counts, and adds error bars
 .. - PR #160: Fix home button doesn't reset proper bounds
 .. - PR #158: output the specular data also in ORSO format
 .. - PR #156: binned off-specular preview plot shows data for all runs

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -602,17 +602,22 @@ class PlotManager(object):
         # format and plot tof data
 
         if self.main_window.ui.xLamda.isChecked():
-            self.main_window.ui.intensity.plot(
+            self.main_window.ui.intensity.errorbar(
                 self.main_window.data_manager.active_channel.wavelength,
-                self.main_window.data_manager.active_channel.tofdata,
+                self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 2],
+                yerr=self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 3],
             )
             self.main_window.ui.intensity.set_xlabel("$\\lambda{}$ [Å]")
         else:
-            self.main_window.ui.intensity.plot(self.main_window.data_manager.active_channel.tofdata)
+            self.main_window.ui.intensity.errorbar(
+                self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 0] / 1000,
+                self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 2],
+                yerr=self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 3],
+            )
             self.main_window.ui.intensity.set_xlabel("ToF [ms]")
 
         # y-label is counts in either case
-        self.main_window.ui.intensity.set_ylabel("Counts")
+        self.main_window.ui.intensity.set_ylabel("Normalized ROI Counts")
 
         # draw and show
         self.main_window.ui.intensity.draw()

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -601,18 +601,24 @@ class PlotManager(object):
 
         # format and plot tof data
 
+        counts_normalized = self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 2]
+        counts_normalized_error = self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 3]
+
         if self.main_window.ui.xLamda.isChecked():
             self.main_window.ui.intensity.errorbar(
                 self.main_window.data_manager.active_channel.wavelength,
-                self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 2],
-                yerr=self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 3],
+                counts_normalized,
+                yerr=counts_normalized_error,
             )
             self.main_window.ui.intensity.set_xlabel("$\\lambda{}$ [Å]")
         else:
+            # convert raw microsecond units to milliseconds to match xtof plot
+            tof_ms = tof_ms = self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 0] / 1000
+
             self.main_window.ui.intensity.errorbar(
-                self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 0] / 1000,
-                self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 2],
-                yerr=self.main_window.data_manager.active_channel.get_tof_counts_table()[0][:, 3],
+                tof_ms,
+                counts_normalized,
+                yerr=counts_normalized_error,
             )
             self.main_window.ui.intensity.set_xlabel("ToF [ms]")
 


### PR DESCRIPTION
## Description of work:

In a recent PR, an intensity plot for direct beam runs was implemented. The CIS requested this plot use normalized values. This PR implements that and also adds error bars.

Check all that apply:
- [X] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [X] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: [9367: [QuickNXS] Reflectivity plot for direct beam should show Intensity vs ToF/WL](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9367)
- Links to related issues or pull requests: https://github.com/neutrons/quicknxs/pull/153


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
