### PR TITLE
Fix reflectivity not updated with changes to direct beam data

### DIFF
--- a/src/quicknxs/interfaces/data_manager.py
+++ b/src/quicknxs/interfaces/data_manager.py
@@ -498,7 +498,7 @@ class DataManager(object):
         """Return the direct beam data object for the active data."""
         return self._find_direct_beam(self._nexus_data)
 
-    def is_same_run(self, run_number_a, run_number_b):
+    def is_same_run(self, run_number_a: str | int, run_number_b: str | int) -> bool:
         """
         Returns True if two run numbers are considered the same.
 
@@ -533,7 +533,7 @@ class DataManager(object):
         ----------
         nexus_data : NexusData
             NexusData run object
-        direct_beam : str
+        direct_beam : str | int
             Direct beam run number
         """
         run_direct_beam = self._find_direct_beam(nexus_data)
@@ -571,6 +571,7 @@ class DataManager(object):
                         if len(keys) > 1:
                             logging.error("More than one cross-section for the direct beam, using the first one")
                         direct_beam = direct_beam_item.cross_sections[keys[0]]
+                        break
             if direct_beam is None:
                 logging.error("The specified direct beam is not available: skipping")
 
@@ -628,7 +629,7 @@ class DataManager(object):
                 return False
         return True
 
-    def reduce_spec(self, direct_beam: Optional[str] = None):
+    def reduce_spec(self, direct_beam: Optional[str | int] = None):
         """
         Calculate reflectivity for all runs in all reduction lists.
 
@@ -636,7 +637,7 @@ class DataManager(object):
 
         Parameters
         ----------
-        updated_direct_beam : Optional[str]
+        direct_beam : Optional[str | int]
             Direct beam run number
         """
         for reduct_list in self.peak_reduction_lists.values():

--- a/src/quicknxs/interfaces/data_manager.py
+++ b/src/quicknxs/interfaces/data_manager.py
@@ -498,6 +498,47 @@ class DataManager(object):
         """Return the direct beam data object for the active data."""
         return self._find_direct_beam(self._nexus_data)
 
+    def is_same_run(self, run_number_a, run_number_b):
+        """
+        Returns True if two run numbers are considered the same.
+
+        Tries to compare the run numbers as integers if possible;
+        falls back to comparing them as-is (e.g., strings).
+
+        Parameters
+        ----------
+        run_number_a : str or int
+            The first run number.
+        run_number_b : str or int
+            The second run number.
+
+        Returns
+        -------
+        bool
+            True if the run numbers are equal (after normalization), False otherwise.
+        """
+
+        def normalize(run):
+            try:
+                return int(run)
+            except (ValueError, TypeError):
+                return run
+
+        return normalize(run_number_a) == normalize(run_number_b)
+
+    def is_direct_beam_for_run(self, nexus_data: NexusData, direct_beam_run: str):
+        """Check if the direct beam is the configured direct beam for the given run.
+
+        Parameters
+        ----------
+        nexus_data : NexusData
+            NexusData run object
+        direct_beam : str
+            Direct beam run number
+        """
+        run_direct_beam = self._find_direct_beam(nexus_data)
+        return run_direct_beam is not None and self.is_same_run(run_direct_beam.number, direct_beam_run)
+
     def _find_direct_beam(self, nexus_data: Union[NexusData, CrossSectionData]) -> Optional[CrossSectionData]:
         """Attempt to find a direct beam data set for a given reflectivity data set.
 
@@ -522,23 +563,14 @@ class DataManager(object):
             raise TypeError("nexus_data must be a NexusData or CrossSectionData object")
 
         if data_xs.configuration is not None and data_xs.configuration.direct_beam is not None:
-            for item in self.direct_beam_list:
-                # convert _run_number to int if it can be
-                try:
-                    _run_number = int(data_xs.configuration.direct_beam)
-                except (ValueError, TypeError):
-                    _run_number = data_xs.configuration.direct_beam
-                # convert item.number to int if it can be
-                try:
-                    item_number = int(item.number)
-                except (ValueError, TypeError):
-                    item_number = item.number
-                if item_number == _run_number:
-                    keys = list(item.cross_sections.keys())
+            data_xs_direct_beam = data_xs.configuration.direct_beam
+            for direct_beam_item in self.direct_beam_list:
+                if self.is_same_run(direct_beam_item.number, data_xs_direct_beam):
+                    keys = list(direct_beam_item.cross_sections.keys())
                     if len(keys) >= 1:
                         if len(keys) > 1:
                             logging.error("More than one cross-section for the direct beam, using the first one")
-                        direct_beam = item.cross_sections[keys[0]]
+                        direct_beam = direct_beam_item.cross_sections[keys[0]]
             if direct_beam is None:
                 logging.error("The specified direct beam is not available: skipping")
 
@@ -596,10 +628,21 @@ class DataManager(object):
                 return False
         return True
 
-    def reduce_spec(self):
-        """Calculate reflectivity for all runs in all reduction lists."""
+    def reduce_spec(self, direct_beam: Optional[str] = None):
+        """
+        Calculate reflectivity for all runs in all reduction lists.
+
+        If a direct beam is given, only calculate reflectivity for the runs using the given direct beam.
+
+        Parameters
+        ----------
+        updated_direct_beam : Optional[str]
+            Direct beam run number
+        """
         for reduct_list in self.peak_reduction_lists.values():
             for nexus_data in reduct_list:
+                if direct_beam is not None and not self.is_direct_beam_for_run(nexus_data, direct_beam):
+                    continue
                 try:
                     self.calculate_reflectivity(nexus_data=nexus_data)
                 except:

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -1169,9 +1169,9 @@ class MainHandler(object):
             self.update_info()
             self.main_window.auto_change_active = False
 
-        # Recalculate reflectivity
+        # Recalculate reflectivity for runs with this direct beam
         try:
-            self._data_manager.calculate_reflectivity(nexus_data=data)
+            self._data_manager.reduce_spec(direct_beam=data.number)
         except:
             self.report_message(
                 "Could not compute reflectivity for %s" % self._data_manager.current_file_name,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,8 +10,12 @@ from pathlib import Path
 import pytest
 from PyQt5.QtCore import QSettings
 
+from quicknxs.interfaces.configuration import Configuration
 from quicknxs.interfaces.data_handling.filepath import RunNumbers
 from quicknxs.interfaces.data_handling.instrument import Instrument
+from quicknxs.interfaces.data_manager import DataManager
+from quicknxs.interfaces.main_window import MainWindow
+from test.ui import ui_utilities
 
 pytest_plugins = ["mantid.fixtures"]
 
@@ -106,3 +110,73 @@ def data_server(DATA_DIR):
             return file_list
 
     return _DataServe()
+
+
+@pytest.fixture
+def main_window_with_data_factory(qtbot):
+    """Test fixture that returns a main window with data loaded into it.
+
+    Create as a factory to be able to do setup e.g. mock functions before instantiating the main window.
+    """
+
+    def _create():
+        Configuration.setup_default_values()
+        main_window = MainWindow()
+        qtbot.addWidget(main_window)
+
+        # load file list
+        ui_utilities.setText(main_window.numberSearchEntry, str(42100), press_enter=True)
+
+        # add two direct beams
+        ui_utilities.set_current_file_by_run_number(main_window, 42100)
+        main_window.actionAddDirectBeam.triggered.emit()
+        ui_utilities.set_current_file_by_run_number(main_window, 42099)
+        main_window.actionAddDirectBeam.triggered.emit()
+
+        # add two data runs
+        ui_utilities.set_current_file_by_run_number(main_window, 42112)
+        main_window.actionAddRefl.triggered.emit()
+        ui_utilities.set_current_file_by_run_number(main_window, 42113)
+        main_window.actionAddRefl.triggered.emit()
+
+        # set the first data run as the active run in the UI
+        main_window.reduction_cell_activated(0, 0)
+
+        return main_window
+
+    return _create
+
+
+@pytest.fixture
+def data_manager_with_data_factory(data_server):
+    """Test fixture that returns a data manager with data loaded into it.
+
+    Create as a factory to be able to do setup e.g. mock functions before instantiating the data manager.
+    """
+
+    def _create():
+        Configuration.setup_default_values()
+
+        manager = DataManager(data_server.directory)
+
+        # Add direct beams
+        manager.load(data_server.path_to("REF_M_42099"), Configuration())
+        manager.add_active_to_direct_beam_list()
+        manager.load(data_server.path_to("REF_M_42100"), Configuration())
+        manager.add_active_to_direct_beam_list()
+
+        # Add reflected runs, direct beams should be automatically matched
+        conf1 = Configuration()
+        conf1.match_direct_beam = True
+        manager.load(data_server.path_to("REF_M_42112"), conf1)
+        manager.add_active_to_reduction()
+        assert manager.get_active_direct_beam().number == "42099"
+        conf2 = Configuration()
+        conf2.match_direct_beam = True
+        manager.load(data_server.path_to("REF_M_42113"), conf2)
+        manager.add_active_to_reduction()
+        assert manager.get_active_direct_beam().number == "42100"
+
+        return manager
+
+    return _create

--- a/test/ui/test_direct_beam_table.py
+++ b/test/ui/test_direct_beam_table.py
@@ -63,5 +63,33 @@ def test_table_connections(qtbot, data_server):
     assert main_window.ui.refXWidth.value() == float(table.item(0, 2).text())
 
 
+@pytest.mark.datarepo
+def test_table_peak_position_change_triggers_plot_update(mocker, main_window_with_data_factory):
+    """Test that changing the peak position in the direct beam table triggers a plot update."""
+    # Mock plotting
+    mock_plot_refl = mocker.patch(
+        "quicknxs.interfaces.plotting.PlotManager.plot_reflectivity_or_intensity", return_value=True
+    )
+
+    main_window = main_window_with_data_factory()
+    table: QtWidgets.QTableWidget = main_window.ui.directBeamTable
+
+    reduction_list = main_window.data_manager.reduction_list
+    mock_refl_run_with_db_42099 = mocker.patch.object(reduction_list[0], "calculate_reflectivity")
+    mock_refl_run_with_db_42100 = mocker.patch.object(reduction_list[1], "calculate_reflectivity")
+
+    # Get call count before
+    plot_refl_call_count = mock_plot_refl.call_count
+
+    # Update peak position in the direct beam table
+    assert table.item(0, 0).text() == "42100"
+    table.item(0, 1).setText("102.0")
+
+    # Verify that the reflected run was updated and that the plot function was called
+    mock_refl_run_with_db_42099.assert_not_called()
+    mock_refl_run_with_db_42100.assert_called_once()
+    assert mock_plot_refl.call_count == plot_refl_call_count + 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/unit/quicknxs/interfaces/test_data_manager.py
+++ b/test/unit/quicknxs/interfaces/test_data_manager.py
@@ -120,6 +120,24 @@ class TestDataManagerTest(object):
         assert len(manager.peak_reduction_lists[1]) == 2
         assert manager.active_reduction_list_index == 1
 
+    @pytest.mark.datarepo
+    def test_reduce_spec(self, mocker, data_manager_with_data_factory):
+        """Test function reduce_spec."""
+        mock_nexus_reflectivity = mocker.patch(
+            "quicknxs.interfaces.data_handling.data_set.NexusData.calculate_reflectivity", return_value=True
+        )
+
+        manager = data_manager_with_data_factory()
+
+        manager.reduce_spec()
+        # assert that the reflectivity was recalculated for the two reflected runs
+        mock_nexus_reflectivity.call_count == 2
+        mock_nexus_reflectivity.reset_mock()
+
+        manager.reduce_spec(direct_beam="42099")
+        # assert that the reflectivity was recalculated for only one run, which matches the direct beam
+        mock_nexus_reflectivity.call_count == 1
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/unit/quicknxs/interfaces/test_data_manager.py
+++ b/test/unit/quicknxs/interfaces/test_data_manager.py
@@ -123,20 +123,19 @@ class TestDataManagerTest(object):
     @pytest.mark.datarepo
     def test_reduce_spec(self, mocker, data_manager_with_data_factory):
         """Test function reduce_spec."""
-        mock_nexus_reflectivity = mocker.patch(
-            "quicknxs.interfaces.data_handling.data_set.NexusData.calculate_reflectivity", return_value=True
-        )
-
         manager = data_manager_with_data_factory()
+        spy_calc_refl_run1 = mocker.spy(manager.reduction_list[0], "calculate_reflectivity")
+        spy_calc_refl_run2 = mocker.spy(manager.reduction_list[1], "calculate_reflectivity")
 
         manager.reduce_spec()
         # assert that the reflectivity was recalculated for the two reflected runs
-        mock_nexus_reflectivity.call_count == 2
-        mock_nexus_reflectivity.reset_mock()
+        assert spy_calc_refl_run1.call_count == 1
+        assert spy_calc_refl_run2.call_count == 1
 
         manager.reduce_spec(direct_beam="42099")
         # assert that the reflectivity was recalculated for only one run, which matches the direct beam
-        mock_nexus_reflectivity.call_count == 1
+        assert spy_calc_refl_run1.call_count == 2
+        assert spy_calc_refl_run2.call_count == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:

After this fix, changing the direct beam data in the table, e.g. peak position, triggers recalculating the reflectivity for the subset of reflected runs that are configured to use the changed direct beam.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] ~~updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)~~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 11653: [quicknxs] Reflectivity plot not updated with changes to direct beam data](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11653)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

1. Load direct beam runs 42099 and 42100.
2. Load reflected runs 42112 and 42113. They should be automatically assigned direct beams in the column "Dir. Run".
3. With a reflected run selected/plotted in the overview, and the bottom right plot showing the reflectivity curve, select the tab "Direct Beam" and change the peak position.
4. Verify that the plot is updated.

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
